### PR TITLE
fixed tests context error

### DIFF
--- a/app.py
+++ b/app.py
@@ -71,8 +71,6 @@ class CancelOrder(Resource):
                         )
 
     def patch(self, order_id):
-        data = CancelOrder.parser.parse_args()
-
         parcel = next(filter(lambda x: x['id'] == order_id, parcels), None)
 
         if parcel is not None:
@@ -97,8 +95,6 @@ class ChangeStatus(Resource):
                         )
 
     def patch(self, order_id):
-        data = ChangeStatus.parser.parse_args()
-
         parcel = next(filter(lambda x: x['id'] == order_id, parcels), None)
 
         if parcel is not None:
@@ -123,8 +119,6 @@ class ChangeLocation(Resource):
                         )
 
     def patch(self, order_id):
-        data = ChangeLocation.parser.parse_args()
-
         parcel = next(filter(lambda x: x['id'] == order_id, parcels), None)
 
         if parcel is not None:
@@ -134,7 +128,7 @@ class ChangeLocation(Resource):
             return {'message': "Parcel with id '{}' does not exist.".format(order_id)}, 404
 
 
-# Fetch all parcel delivery order by a specific user
+# Change destination -- only admin
 class ChangeDestination(Resource):
     parser = reqparse.RequestParser()
     parser.add_argument('to',
@@ -149,7 +143,6 @@ class ChangeDestination(Resource):
                         )
 
     def patch(self, order_id):
-        data = ChangeDestination.parser.parse_args()
         parcel = next(filter(lambda x: x['id'] == order_id, parcels), None)
 
         if parcel is not None:
@@ -159,7 +152,7 @@ class ChangeDestination(Resource):
             return {'message': "Parcel with id '{}' does not exist.".format(order_id)}, 404
 
 
-#
+# Flask Restful Routes
 api.add_resource(ParcelsList, '/parcels')
 api.add_resource(Parcel, '/parcels/<string:order_id>')
 api.add_resource(CancelOrder, '/parcels/<string:order_id>/cancel')

--- a/tests/functional_test.py
+++ b/tests/functional_test.py
@@ -1,7 +1,6 @@
 # This Python file uses the following encoding: utf-8
 import pytest
 import app
-from flask import request
 
 
 @pytest.fixture
@@ -14,9 +13,6 @@ def test_hello_world(my_app):
     # res = my_app.get("/")
     # assert res.status_code == 200
     assert my_app
-
-
-# TODO: FIX CONTEXT ERROR IN ALL PATCH REQUEST TESTS
 
 
 # Fetch all parcel delivery orders


### PR DESCRIPTION
`data = parser.parse_args()` is not required in `patch` calls. 